### PR TITLE
refactor ThemeChanger to use resolvedTheme

### DIFF
--- a/components/ThemeChanger.tsx
+++ b/components/ThemeChanger.tsx
@@ -4,18 +4,10 @@ import { HiBan, HiMoon, HiOutlineSun } from 'react-icons/hi';
 
 export default function ThemeChanger() {
   const [mounted, setMounted] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
   // When mounted on client, now we can show the UI
   useEffect(() => setMounted(true), []);
-
-  function changeTheme() {
-    if (theme === 'dark') {
-      setTheme('light');
-    } else {
-      setTheme('dark');
-    }
-  }
 
   if (!mounted)
     return (
@@ -24,17 +16,19 @@ export default function ThemeChanger() {
       </button>
     );
 
-  return (
+  return resolvedTheme === 'dark' ? (
     <button
-      className='dark:bg-amber-200 p-1 bg-indigo-600 rounded'
-      onClick={changeTheme}>
-      {theme === 'dark' ? (
-        // slate-800
-        <HiOutlineSun color='rgb(30 41 59 / var(--tw-bg-opacity)' size={30} />
-      ) : (
-        // amber-100
-        <HiMoon color='rgb(254 243 199 / var(--tw-text-opacity)' size={30} />
-      )}
+      className='bg-amber-200 p-1 rounded'
+      onClick={() => setTheme('light')}>
+      {/* slate-800 */}
+      <HiOutlineSun color='rgb(30 41 59 / var(--tw-bg-opacity)' size={30} />
+    </button>
+  ) : (
+    <button
+      className='p-1 bg-indigo-600 rounded'
+      onClick={() => setTheme('dark')}>
+      {/* amber-100 */}
+      <HiMoon color='rgb(254 243 199 / var(--tw-text-opacity)' size={30} />
     </button>
   );
 }


### PR DESCRIPTION
bug fix for initial hydration of page where correct icon for theme switcher doesn't show. We must use `resolvedTheme` instead of `theme` in conditional rendering logic.